### PR TITLE
Getting network controls

### DIFF
--- a/epynet/epanet2.py
+++ b/epynet/epanet2.py
@@ -684,13 +684,19 @@ class EPANET2(object):
         """retrieves the current simulation time t as datetime.timedelta instance"""
         return datetime.timedelta(seconds= self._current_simulation_time.value )
 
-    def ENnextH(self):
+    def ENnextH(self,timestep):
         """Determines the length of time until the next hydraulic event occurs in an extended period
            simulation."""
+        
+        sum_steps = 0
         _deltat= ctypes.c_long()
-        ierr= self._lib.EN_nextH(self.ph, ctypes.byref(_deltat))
-        if ierr!=0: raise ENtoolkitError(self, ierr)
-        return _deltat.value
+        while sum_steps < timestep:
+            ierr= self._lib.EN_nextH(self.ph, ctypes.byref(_deltat))
+            if ierr!=0: 
+                print(f"Error code {ierr}")
+                return None
+            sum_steps += _deltat.value
+        return sum_steps
 
 
     def ENcloseH(self):

--- a/epynet/epanet2.py
+++ b/epynet/epanet2.py
@@ -381,7 +381,7 @@ class EPANET2(object):
                     EN_TOLERANCE 
                     EN_EMITEXPON 
                     EN_DEMANDMULT""" 
-        j= ctypes.c_int()
+        j= ctypes.c_float()                                                    #<--- solved: c_int() changed to c_float()
         ierr= self._lib.EN_getoption(self.ph, optioncode, ctypes.byref(j))
         if ierr!=0: raise ENtoolkitError(self, ierr)
         return j.value
@@ -617,7 +617,7 @@ class EPANET2(object):
         if ierr!=0: raise ENtoolkitError(self, ierr)
 
 
-    def ENsetoption(self, optioncode, value):
+    def ENsetoption(self, paramcode, value):                      #<------------- solved: optioncode changed to paramcode
         """Sets the value of a particular analysis option.
 
         Arguments:

--- a/epynet/epanet2.py
+++ b/epynet/epanet2.py
@@ -691,7 +691,7 @@ class EPANET2(object):
         """retrieves the current simulation time t as datetime.timedelta instance"""
         return datetime.timedelta(seconds= self._current_simulation_time.value )
 
-        def ENnextH(self):
+    def ENnextH(self):
         """Determines the length of time until the next hydraulic event occurs in an extended period
            simulation."""
         _deltat= ctypes.c_long()


### PR DESCRIPTION
    def ENgetcontrol(self, cindex):#<------------
        """Retrieves the parameters of a simple control statement.
        Arguments:
           cindex:  control statement index
        
        returns: ctype:  control type code:
                        EN_LOWLEVEL   (Low Level Control)
                        EN_HILEVEL    (High Level Control)
                        EN_TIMER      (Timer Control)       
                        EN_TIMEOFDAY  (Time-of-Day Control)
                lindex:  index of link being controlled
                setting: value of the control setting
                nindex:  index of controlling node
                level:   value of controlling water level or pressure for level controls 
                            or of time of control action (in seconds) for time-based controls
        """
        type_ = ctypes.c_int()#<--------------
        lindex = ctypes.c_int()#<-------------
        setting = ctypes.c_float()#<----------
        nindex = ctypes.c_int()#<------------
        level = ctypes.c_float()#<------------
        ierr = self._lib.EN_getcontrol(self.ph, ctypes.c_int(cindex), ctypes.byref(type_), ctypes.byref(lindex),
                                        ctypes.byref(setting), ctypes.byref(nindex),ctypes.byref(level), ctypes.byref(level)) #<------------
        if ierr!=0: raise ENtoolkitError(self,ierr)
        return type_.value,lindex.value, setting.value, nindex.value, level.value#<------------

I modified this function to return the control rule parameters, in this case I used the ctypes.byref method to pass the correct arguments to ENgetcontrol function, and returned them. Now the Python function only receives one parameter, the control rule index.